### PR TITLE
Add MCP freeze debugging test suite

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,19 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    headless: false,
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  timeout: 30000,
+  expect: {
+    timeout: 10000,
+  },
+});

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,82 @@
+# MCP Freeze Debugging Tests
+
+This test suite is designed to help debug the MCP call freezing issue where the app hangs when making MCP calls, with error logs showing:
+
+```
+[1] ERROR - filesystem/stderr
+Error: Allowed directories: [ '/Users' ]
+
+[2] ERROR - filesystem/stderr  
+Error: Secure MCP Filesystem Server running on stdio
+```
+
+## Test Files
+
+### 1. `mcp-freeze-debug.spec.js`
+Main Playwright tests that run the full Electron app and test for freezing during normal usage:
+- App startup without freezing during MCP server initialization
+- MCP log display functionality
+- Error handling without UI blocking
+- Timeout handling for hanging MCP calls
+- Analysis of specific filesystem server errors
+
+### 2. `mcp-unit-tests.spec.js`
+Unit tests for individual MCP components:
+- MCP server process management
+- JSON-RPC message parsing
+- MCP logging performance
+- Electron IPC communication handling
+
+### 3. `mcp-freeze-reproduction.spec.js`
+Targeted tests to reproduce the exact freezing scenario:
+- Direct filesystem server testing to reproduce stderr messages
+- Multiple server startup race condition testing
+- Communication protocol testing to identify blocking points
+
+## Running the Tests
+
+```bash
+# Run all tests headlessly
+npm test
+
+# Run tests with browser UI visible (recommended for debugging)
+npm run test:headed
+
+# Run tests with Playwright's interactive UI
+npm run test:ui
+
+# Run specific test file
+npx playwright test tests/mcp-freeze-reproduction.spec.js --headed
+```
+
+## What the Tests Check
+
+1. **App Responsiveness**: Ensures the Electron app doesn't freeze during MCP server startup
+2. **Error Handling**: Verifies that stderr messages from MCP servers don't cause blocking
+3. **Communication Flow**: Tests the JSON-RPC communication that might be causing hangs
+4. **Process Management**: Checks that MCP server child processes are managed correctly
+5. **Race Conditions**: Tests for issues when multiple servers start simultaneously
+
+## Expected Findings
+
+Based on the error logs, the tests should help identify:
+
+- **Root Cause**: The filesystem server outputs informational messages to stderr ("Allowed directories", "Secure MCP Filesystem Server running on stdio") which may be causing the parent process to block when reading stderr
+- **Communication Issues**: JSON-RPC initialization or subsequent calls may hang
+- **Resource Management**: Potential issues with stdio pipe handling or process cleanup
+
+## Debugging Tips
+
+1. **Screenshots**: Failed tests will capture screenshots in `tests/screenshots/`
+2. **Console Output**: Tests log detailed information about MCP server behavior
+3. **Timing Analysis**: Tests measure response times to identify blocking operations
+4. **Process Isolation**: Tests run MCP servers independently to isolate issues
+
+## Next Steps
+
+If tests confirm the freezing issue:
+
+1. **Stderr Handling**: Modify the main process to handle MCP server stderr non-blockingly
+2. **Timeout Implementation**: Add timeouts to all MCP operations
+3. **Error Recovery**: Implement graceful handling of MCP server failures
+4. **Alternative Communication**: Consider using sockets instead of stdio for MCP communication

--- a/tests/mcp-freeze-debug.spec.js
+++ b/tests/mcp-freeze-debug.spec.js
@@ -1,0 +1,232 @@
+import { test, expect } from '@playwright/test';
+import { spawn } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.join(__dirname, '..');
+
+/**
+ * Test suite to debug MCP call freezing issues
+ * Based on error logs showing filesystem/stderr errors and potential stdio blocking
+ */
+test.describe('MCP Call Freeze Debugging', () => {
+  let electronApp;
+  
+  test.beforeEach(async ({ _electron }) => {
+    // Start Electron app
+    electronApp = await _electron.launch({
+      args: [projectRoot, '--dev'],
+      env: {
+        ...process.env,
+        NODE_ENV: 'test'
+      }
+    });
+  });
+
+  test.afterEach(async () => {
+    if (electronApp) {
+      await electronApp.close();
+    }
+  });
+
+  test('should start app without freezing during MCP server initialization', async () => {
+    const window = await electronApp.firstWindow();
+    
+    // Wait for app to load and check it doesn't freeze
+    await expect(window).toHaveTitle(/Tune Chat/);
+    
+    // Look for MCP status indicators in the UI
+    const mcpStatusIndicator = window.locator('[data-testid="mcp-status"], .mcp-status, [class*="mcp-status"]');
+    
+    // Give MCP servers time to start (but not too long to avoid hanging tests)
+    await window.waitForTimeout(5000);
+    
+    // Check if the window is still responsive
+    const inputField = window.locator('input, textarea').first();
+    if (await inputField.isVisible()) {
+      await inputField.fill('test responsiveness');
+      await expect(inputField).toHaveValue('test responsiveness');
+    }
+  });
+
+  test('should display MCP call logs without freezing', async () => {
+    const window = await electronApp.firstWindow();
+    
+    // Wait for app to load
+    await window.waitForLoadState('domcontentloaded');
+    
+    // Look for MCP logs section
+    const mcpLogsSection = window.locator('#mcp-logs, [data-testid="mcp-logs"], .mcp-logs');
+    
+    // Wait a bit for MCP servers to initialize and generate logs
+    await window.waitForTimeout(3000);
+    
+    // Check if MCP logs are visible and contain error information
+    const errorLogs = window.locator('text=/ERROR.*filesystem.*stderr/i');
+    const allowedDirsError = window.locator('text=/Allowed directories/i');
+    const stdioError = window.locator('text=/Secure MCP Filesystem Server running on stdio/i');
+    
+    // Take screenshot for debugging
+    await window.screenshot({ path: 'tests/screenshots/mcp-logs-state.png' });
+    
+    // Verify the window is still responsive after MCP errors
+    await expect(window.locator('body')).toBeVisible();
+  });
+
+  test('should handle MCP server stderr without blocking', async () => {
+    const window = await electronApp.firstWindow();
+    
+    // Monitor console errors
+    const consoleErrors = [];
+    window.on('console', msg => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+    
+    await window.waitForLoadState('domcontentloaded');
+    
+    // Wait for MCP servers to start and potentially generate stderr
+    await window.waitForTimeout(5000);
+    
+    // Check if the app is still interactive despite stderr errors
+    const chatInput = window.locator('textarea, input[type="text"]').first();
+    if (await chatInput.isVisible()) {
+      await chatInput.fill('Testing after MCP stderr');
+      
+      // Verify the input worked (app didn't freeze)
+      await expect(chatInput).toHaveValue('Testing after MCP stderr');
+    }
+    
+    console.log('Console errors captured:', consoleErrors);
+  });
+
+  test('should timeout and fail gracefully if MCP calls hang', async () => {
+    const window = await electronApp.firstWindow();
+    
+    await window.waitForLoadState('domcontentloaded');
+    
+    // Try to trigger an MCP call if there's a way to do so in the UI
+    const sendButton = window.locator('button:has-text("Send"), [data-testid="send-button"], .send-button');
+    const messageInput = window.locator('textarea, input[type="text"]').first();
+    
+    if (await messageInput.isVisible() && await sendButton.isVisible()) {
+      await messageInput.fill('Test message that might trigger MCP call');
+      
+      // Set a reasonable timeout for the send operation
+      await Promise.race([
+        sendButton.click(),
+        new Promise((_, reject) => 
+          setTimeout(() => reject(new Error('MCP call timed out after 10 seconds')), 10000)
+        )
+      ]).catch(error => {
+        console.log('Expected timeout or error:', error.message);
+        // This is expected if MCP calls are hanging
+      });
+      
+      // Verify app is still responsive after timeout
+      await expect(window.locator('body')).toBeVisible();
+    }
+  });
+
+  test('should show MCP filesystem server errors in logs', async () => {
+    const window = await electronApp.firstWindow();
+    
+    await window.waitForLoadState('domcontentloaded');
+    
+    // Wait for MCP logs to populate
+    await window.waitForTimeout(5000);
+    
+    // Look for specific error patterns from the logs
+    const logs = await window.textContent('body');
+    
+    // Check for the specific errors mentioned in the issue
+    const hasAllowedDirsError = logs.includes('Allowed directories');
+    const hasStdioError = logs.includes('Secure MCP Filesystem Server running on stdio');
+    const hasFilesystemError = logs.includes('filesystem/stderr');
+    
+    console.log('MCP Error Analysis:');
+    console.log('- Allowed directories error found:', hasAllowedDirsError);
+    console.log('- Stdio error found:', hasStdioError);
+    console.log('- Filesystem stderr error found:', hasFilesystemError);
+    
+    // Take detailed screenshot for analysis
+    await window.screenshot({ 
+      path: 'tests/screenshots/mcp-error-analysis.png',
+      fullPage: true 
+    });
+    
+    // The presence of these errors indicates the filesystem server is starting
+    // but encountering configuration issues
+    if (hasAllowedDirsError || hasStdioError || hasFilesystemError) {
+      console.log('MCP filesystem server errors detected - this may be causing the freeze');
+    }
+  });
+});
+
+test.describe('MCP Server Direct Testing', () => {
+  test('should test MCP filesystem server directly', async () => {
+    // Test the MCP filesystem server in isolation
+    const serverProcess = spawn('npx', ['@modelcontextprotocol/server-filesystem', '/Users'], {
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+    
+    let stdoutData = '';
+    let stderrData = '';
+    let processExited = false;
+    
+    serverProcess.stdout.on('data', (data) => {
+      stdoutData += data.toString();
+    });
+    
+    serverProcess.stderr.on('data', (data) => {
+      stderrData += data.toString();
+    });
+    
+    serverProcess.on('exit', (code) => {
+      processExited = true;
+      console.log('MCP filesystem server exited with code:', code);
+    });
+    
+    // Wait a bit for the server to start
+    await new Promise(resolve => setTimeout(resolve, 3000));
+    
+    console.log('MCP Server Direct Test Results:');
+    console.log('- Stdout:', stdoutData);
+    console.log('- Stderr:', stderrData);
+    console.log('- Process exited:', processExited);
+    
+    // Send a simple JSON-RPC message to test communication
+    const testMessage = JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'initialize',
+      id: 1,
+      params: {}
+    }) + '\n';
+    
+    serverProcess.stdin.write(testMessage);
+    
+    // Wait for response
+    await new Promise(resolve => setTimeout(resolve, 2000));
+    
+    console.log('After sending initialize message:');
+    console.log('- Additional stdout:', stdoutData);
+    console.log('- Additional stderr:', stderrData);
+    
+    // Clean up
+    serverProcess.kill();
+    
+    // Analyze results
+    expect(stderrData).toBeTruthy(); // We expect stderr based on the error logs
+    
+    if (stderrData.includes('Allowed directories')) {
+      console.log('✓ Confirmed: Filesystem server outputs "Allowed directories" to stderr');
+    }
+    
+    if (stderrData.includes('Secure MCP Filesystem Server running on stdio')) {
+      console.log('✓ Confirmed: Filesystem server outputs startup message to stderr');
+    }
+  });
+});

--- a/tests/mcp-freeze-reproduction.spec.js
+++ b/tests/mcp-freeze-reproduction.spec.js
@@ -1,0 +1,279 @@
+import { test, expect } from '@playwright/test';
+import { spawn } from 'child_process';
+
+/**
+ * Tests specifically designed to reproduce the exact MCP freezing issue
+ * Based on the error logs: filesystem/stderr with "Allowed directories" and stdio messages
+ */
+test.describe('MCP Freeze Reproduction', () => {
+  
+  test('reproduce filesystem server stderr blocking issue', async () => {
+    console.log('=== REPRODUCING MCP FILESYSTEM SERVER ISSUE ===');
+    
+    // This test reproduces the exact scenario from the logs
+    const serverProcess = spawn('npx', ['@modelcontextprotocol/server-filesystem', '/Users'], {
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+    
+    let stderrMessages = [];
+    let stdoutMessages = [];
+    let isBlocked = false;
+    
+    // Capture stderr (this is where the problematic messages appear)
+    serverProcess.stderr.on('data', (data) => {
+      const message = data.toString();
+      stderrMessages.push(message);
+      console.log('STDERR:', message.trim());
+      
+      // Check for the specific error messages from the user's logs
+      if (message.includes('Allowed directories')) {
+        console.log('✓ Found "Allowed directories" message in stderr');
+      }
+      if (message.includes('Secure MCP Filesystem Server running on stdio')) {
+        console.log('✓ Found "Secure MCP Filesystem Server running on stdio" message');
+      }
+    });
+    
+    serverProcess.stdout.on('data', (data) => {
+      const message = data.toString();
+      stdoutMessages.push(message);
+      console.log('STDOUT:', message.trim());
+    });
+    
+    // Set up a test to detect if the process blocks
+    const blockDetector = setTimeout(() => {
+      isBlocked = true;
+      console.log('⚠️ POTENTIAL BLOCK DETECTED: No response after 5 seconds');
+    }, 5000);
+    
+    serverProcess.on('spawn', () => {
+      console.log('✓ Server process spawned successfully');
+      clearTimeout(blockDetector);
+    });
+    
+    // Wait for initial stderr messages (the ones causing issues)
+    await new Promise(resolve => setTimeout(resolve, 3000));
+    
+    console.log('\n=== ANALYSIS ===');
+    console.log('Stderr messages count:', stderrMessages.length);
+    console.log('Stdout messages count:', stdoutMessages.length);
+    console.log('Process blocked:', isBlocked);
+    
+    // Now try to communicate with the server (this might cause the freeze)
+    console.log('\n=== ATTEMPTING COMMUNICATION ===');
+    
+    const communicationTest = new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error('Communication timed out - likely frozen'));
+      }, 10000);
+      
+      let responseReceived = false;
+      
+      // Listen for any response
+      const responseHandler = (data) => {
+        responseReceived = true;
+        clearTimeout(timeout);
+        resolve(data.toString());
+      };
+      
+      serverProcess.stdout.once('data', responseHandler);
+      
+      // Send initialize message (JSON-RPC)
+      const initMessage = JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'initialize',
+        id: 1,
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '1.0.0' }
+        }
+      }) + '\n';
+      
+      console.log('Sending initialize message...');
+      serverProcess.stdin.write(initMessage);
+      
+      // If no response in 3 seconds, that's suspicious
+      setTimeout(() => {
+        if (!responseReceived) {
+          console.log('⚠️  No response to initialize message - potential freeze point');
+        }
+      }, 3000);
+    });
+    
+    let communicationResult;
+    try {
+      communicationResult = await communicationTest;
+      console.log('✓ Communication successful:', communicationResult.trim());
+    } catch (error) {
+      console.log('✗ Communication failed:', error.message);
+      communicationResult = null;
+    }
+    
+    // Clean up
+    serverProcess.kill('SIGTERM');
+    
+    // Wait a moment for cleanup
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    
+    console.log('\n=== FINAL ANALYSIS ===');
+    
+    // Analyze the results to identify the freeze cause
+    const hasAllowedDirsMsg = stderrMessages.some(msg => msg.includes('Allowed directories'));
+    const hasStdioMsg = stderrMessages.some(msg => msg.includes('Secure MCP Filesystem Server running on stdio'));
+    const communicationWorked = communicationResult !== null;
+    
+    console.log('Key findings:');
+    console.log('- "Allowed directories" in stderr:', hasAllowedDirsMsg);
+    console.log('- "Secure MCP Filesystem Server running on stdio" in stderr:', hasStdioMsg);
+    console.log('- JSON-RPC communication worked:', communicationWorked);
+    console.log('- Process appeared blocked:', isBlocked);
+    
+    // This helps identify if the issue is with:
+    // 1. Server startup (stderr messages)
+    // 2. JSON-RPC communication
+    // 3. Process management
+    
+    if (hasAllowedDirsMsg && hasStdioMsg && !communicationWorked) {
+      console.log('\n🎯 LIKELY FREEZE CAUSE: Server starts and outputs to stderr, but JSON-RPC communication hangs');
+      console.log('   This suggests the issue is in the stdio pipe handling or JSON-RPC protocol implementation');
+    }
+    
+    // The test should pass if we can reproduce the issue
+    expect(hasAllowedDirsMsg).toBe(true);
+    expect(hasStdioMsg).toBe(true);
+  });
+  
+  test('test multiple server startup race condition', async () => {
+    console.log('=== TESTING MULTIPLE SERVER STARTUP ===');
+    
+    // Test if starting multiple MCP servers simultaneously causes issues
+    // (as the app starts both filesystem and browser servers)
+    
+    const servers = [
+      { name: 'filesystem', cmd: 'npx', args: ['@modelcontextprotocol/server-filesystem', '/Users'] },
+      { name: 'browser', cmd: 'npx', args: ['@browsermcp/mcp@latest'] }
+    ];
+    
+    const serverProcesses = [];
+    const serverResults = [];
+    
+    // Start both servers simultaneously (like the app does)
+    for (const server of servers) {
+      const process = spawn(server.cmd, server.args, {
+        stdio: ['pipe', 'pipe', 'pipe']
+      });
+      
+      serverProcesses.push({ process, name: server.name });
+      
+      const result = {
+        name: server.name,
+        stderr: [],
+        stdout: [],
+        spawned: false,
+        error: null
+      };
+      
+      process.stderr.on('data', (data) => {
+        result.stderr.push(data.toString());
+        console.log(`${server.name} STDERR:`, data.toString().trim());
+      });
+      
+      process.stdout.on('data', (data) => {
+        result.stdout.push(data.toString());
+        console.log(`${server.name} STDOUT:`, data.toString().trim());
+      });
+      
+      process.on('spawn', () => {
+        result.spawned = true;
+        console.log(`✓ ${server.name} server spawned`);
+      });
+      
+      process.on('error', (error) => {
+        result.error = error.message;
+        console.log(`✗ ${server.name} server error:`, error.message);
+      });
+      
+      serverResults.push(result);
+    }
+    
+    // Wait for servers to start
+    await new Promise(resolve => setTimeout(resolve, 5000));
+    
+    console.log('\n=== RACE CONDITION ANALYSIS ===');
+    
+    for (const result of serverResults) {
+      console.log(`${result.name} server:`);
+      console.log(`  - Spawned: ${result.spawned}`);
+      console.log(`  - Stderr messages: ${result.stderr.length}`);
+      console.log(`  - Stdout messages: ${result.stdout.length}`);
+      console.log(`  - Error: ${result.error || 'none'}`);
+    }
+    
+    // Test communication with both servers
+    console.log('\n=== TESTING SIMULTANEOUS COMMUNICATION ===');
+    
+    const communicationPromises = serverProcesses.map(({ process, name }) => {
+      return new Promise((resolve) => {
+        const timeout = setTimeout(() => {
+          resolve({ name, success: false, reason: 'timeout' });
+        }, 5000);
+        
+        const initMessage = JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'initialize',
+          id: 1,
+          params: {
+            protocolVersion: '2024-11-05',
+            capabilities: {},
+            clientInfo: { name: 'test-client', version: '1.0.0' }
+          }
+        }) + '\n';
+        
+        process.stdout.once('data', () => {
+          clearTimeout(timeout);
+          resolve({ name, success: true, reason: 'response received' });
+        });
+        
+        try {
+          process.stdin.write(initMessage);
+        } catch (error) {
+          clearTimeout(timeout);
+          resolve({ name, success: false, reason: error.message });
+        }
+      });
+    });
+    
+    const communicationResults = await Promise.all(communicationPromises);
+    
+    console.log('Communication results:');
+    communicationResults.forEach(result => {
+      console.log(`  ${result.name}: ${result.success ? '✓' : '✗'} (${result.reason})`);
+    });
+    
+    // Clean up all processes
+    serverProcesses.forEach(({ process }) => {
+      try {
+        process.kill('SIGTERM');
+      } catch (error) {
+        console.log('Error killing process:', error.message);
+      }
+    });
+    
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    
+    // Analysis
+    const filesystemResult = serverResults.find(r => r.name === 'filesystem');
+    const hasFilesystemIssue = filesystemResult && 
+      filesystemResult.stderr.some(msg => 
+        msg.includes('Allowed directories') || msg.includes('Secure MCP Filesystem Server')
+      );
+    
+    if (hasFilesystemIssue) {
+      console.log('\n🎯 CONFIRMED: Filesystem server produces the problematic stderr messages');
+      console.log('   These messages may be causing the parent process to hang when reading stderr');
+    }
+    
+    expect(serverResults.length).toBe(2);
+  });
+});

--- a/tests/mcp-unit-tests.spec.js
+++ b/tests/mcp-unit-tests.spec.js
@@ -1,0 +1,260 @@
+import { test, expect } from '@playwright/test';
+import { spawn } from 'child_process';
+import { EventEmitter } from 'events';
+
+/**
+ * Unit tests to isolate and test MCP components that might cause freezing
+ */
+test.describe('MCP Unit Tests', () => {
+  
+  test('MCP server process management should not block', async () => {
+    // Test that spawning MCP servers doesn't cause blocking
+    const servers = [
+      {
+        name: 'filesystem',
+        command: 'npx',
+        args: ['@modelcontextprotocol/server-filesystem', '/Users']
+      },
+      {
+        name: 'browser',
+        command: 'npx', 
+        args: ['@browsermcp/mcp@latest']
+      }
+    ];
+    
+    const results = await Promise.allSettled(
+      servers.map(server => testServerStartup(server))
+    );
+    
+    results.forEach((result, index) => {
+      console.log(`Server ${servers[index].name}:`, 
+        result.status === 'fulfilled' ? 'OK' : `Failed: ${result.reason}`);
+    });
+    
+    // At least one server should start without hanging
+    const successCount = results.filter(r => r.status === 'fulfilled').length;
+    expect(successCount).toBeGreaterThan(0);
+  });
+
+  test('JSON-RPC message parsing should handle malformed input', async () => {
+    // Test the JSON-RPC parsing logic that might cause freezing
+    const testMessages = [
+      '{"jsonrpc": "2.0", "method": "test", "id": 1}',
+      '{"invalid": "json"',
+      '',
+      'not json at all',
+      '{"jsonrpc": "2.0", "method": "test"}\n{"jsonrpc": "2.0", "method": "test2"}',
+      '{"jsonrpc": "2.0", "error": {"code": -1, "message": "Test error"}}'
+    ];
+    
+    for (const message of testMessages) {
+      try {
+        const parsed = parseJSONRPCMessage(message);
+        console.log(`Parsed "${message.substring(0, 30)}...":`, parsed);
+      } catch (error) {
+        console.log(`Failed to parse "${message.substring(0, 30)}...":`, error.message);
+        // Parsing failures should not cause freezing
+        expect(error).toBeInstanceOf(Error);
+      }
+    }
+  });
+
+  test('MCP logging should not cause memory leaks or blocking', async () => {
+    // Simulate the MCP logging functionality
+    const mcpLogger = new MCPLoggerSimulator();
+    
+    // Generate lots of log entries quickly
+    const logCount = 1000;
+    const startTime = Date.now();
+    
+    for (let i = 0; i < logCount; i++) {
+      mcpLogger.logCall({
+        type: i % 2 === 0 ? 'stdout' : 'stderr',
+        server: 'filesystem',
+        timestamp: new Date(),
+        input: `Test input ${i}`,
+        output: `Test output ${i}`,
+        error: i % 10 === 0 ? `Test error ${i}` : null
+      });
+    }
+    
+    const endTime = Date.now();
+    const duration = endTime - startTime;
+    
+    console.log(`Logged ${logCount} entries in ${duration}ms`);
+    console.log(`Average: ${(duration / logCount).toFixed(2)}ms per log entry`);
+    
+    // Logging should be fast and not block
+    expect(duration).toBeLessThan(5000); // Should complete in under 5 seconds
+    expect(mcpLogger.getLogs().length).toBe(logCount);
+  });
+
+  test('Electron IPC communication should handle MCP data without blocking', async () => {
+    // Test IPC message handling that might cause freezing
+    const ipcSimulator = new IPCSimulator();
+    
+    const testMessages = [
+      { channel: 'mcp-call', data: { method: 'filesystem/read', params: {} } },
+      { channel: 'mcp-logs-request', data: {} },
+      { channel: 'mcp-server-status', data: { server: 'filesystem' } },
+      { channel: 'mcp-call', data: { method: 'filesystem/write', params: { path: '/test', content: 'test' } } }
+    ];
+    
+    const startTime = Date.now();
+    
+    for (const message of testMessages) {
+      await ipcSimulator.send(message.channel, message.data);
+      
+      // Ensure each message is processed quickly
+      const messageTime = Date.now() - startTime;
+      expect(messageTime).toBeLessThan(1000); // Each message should process in under 1 second
+    }
+    
+    console.log('All IPC messages processed successfully');
+  });
+});
+
+// Helper functions to simulate MCP components
+
+function testServerStartup(serverConfig) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      process.kill();
+      reject(new Error('Server startup timed out'));
+    }, 10000); // 10 second timeout
+    
+    const process = spawn(serverConfig.command, serverConfig.args, {
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+    
+    let hasOutput = false;
+    
+    process.stdout.on('data', (data) => {
+      hasOutput = true;
+      console.log(`${serverConfig.name} stdout:`, data.toString());
+    });
+    
+    process.stderr.on('data', (data) => {
+      hasOutput = true;
+      console.log(`${serverConfig.name} stderr:`, data.toString());
+    });
+    
+    process.on('spawn', () => {
+      console.log(`${serverConfig.name} server spawned successfully`);
+      
+      // Give it a moment to output something, then resolve
+      setTimeout(() => {
+        clearTimeout(timeout);
+        process.kill();
+        resolve({
+          spawned: true,
+          hasOutput,
+          name: serverConfig.name
+        });
+      }, 2000);
+    });
+    
+    process.on('error', (error) => {
+      clearTimeout(timeout);
+      reject(new Error(`${serverConfig.name} server failed to start: ${error.message}`));
+    });
+  });
+}
+
+function parseJSONRPCMessage(message) {
+  if (!message || message.trim() === '') {
+    throw new Error('Empty message');
+  }
+  
+  // Handle multiple JSON objects in one message (common issue)
+  const lines = message.split('\n').filter(line => line.trim());
+  const results = [];
+  
+  for (const line of lines) {
+    if (line.trim()) {
+      try {
+        const parsed = JSON.parse(line);
+        results.push(parsed);
+      } catch (error) {
+        throw new Error(`Invalid JSON: ${error.message}`);
+      }
+    }
+  }
+  
+  return results.length === 1 ? results[0] : results;
+}
+
+class MCPLoggerSimulator {
+  constructor() {
+    this.logs = [];
+    this.maxLogs = 10000; // Prevent memory leaks
+  }
+  
+  logCall(logEntry) {
+    // Simulate the logging functionality from the main app
+    this.logs.push({
+      id: this.logs.length + 1,
+      timestamp: logEntry.timestamp || new Date(),
+      type: logEntry.type,
+      server: logEntry.server,
+      input: logEntry.input,
+      output: logEntry.output,
+      error: logEntry.error
+    });
+    
+    // Prevent memory leak by limiting log history
+    if (this.logs.length > this.maxLogs) {
+      this.logs = this.logs.slice(-this.maxLogs);
+    }
+  }
+  
+  getLogs() {
+    return [...this.logs]; // Return copy to prevent mutation
+  }
+  
+  clearLogs() {
+    this.logs = [];
+  }
+}
+
+class IPCSimulator extends EventEmitter {
+  constructor() {
+    super();
+    this.handlers = new Map();
+  }
+  
+  async send(channel, data) {
+    // Simulate IPC message handling with potential for blocking
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error(`IPC message on channel '${channel}' timed out`));
+      }, 5000);
+      
+      // Simulate async processing
+      setImmediate(() => {
+        try {
+          const response = this.handleMessage(channel, data);
+          clearTimeout(timeout);
+          resolve(response);
+        } catch (error) {
+          clearTimeout(timeout);
+          reject(error);
+        }
+      });
+    });
+  }
+  
+  handleMessage(channel, data) {
+    // Simulate the IPC handlers from main.js
+    switch (channel) {
+      case 'mcp-call':
+        return { success: true, result: 'MCP call simulated' };
+      case 'mcp-logs-request':
+        return { logs: [] };
+      case 'mcp-server-status':
+        return { status: 'running', server: data.server };
+      default:
+        throw new Error(`Unknown IPC channel: ${channel}`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add comprehensive Playwright test suite to debug MCP call freezing issues
- Create targeted tests for filesystem server stderr handling and stdio communication
- Include timeout handling and screenshot capture for debugging failed scenarios

## Problem
The app freezes when making MCP calls, with error logs showing:
```
[1] ERROR - filesystem/stderr
Error: Allowed directories: [ '/Users' ]

[2] ERROR - filesystem/stderr  
Error: Secure MCP Filesystem Server running on stdio
```

## Solution
This PR adds three test files to isolate and reproduce the freezing issue:

1. **`mcp-freeze-debug.spec.js`** - Full Electron app tests for responsiveness during MCP operations
2. **`mcp-unit-tests.spec.js`** - Component isolation tests for MCP logging, IPC, and JSON-RPC parsing  
3. **`mcp-freeze-reproduction.spec.js`** - Direct reproduction tests targeting the specific stderr messages

## Test Features
- **Freeze Detection**: Identifies when the app becomes unresponsive
- **Error Log Analysis**: Specifically targets "Allowed directories" and stdio server messages
- **Timeout Handling**: Prevents tests from hanging indefinitely
- **Screenshot Capture**: Visual debugging for failed scenarios
- **Direct Server Testing**: Tests MCP servers in isolation to identify blocking points

## Usage
```bash
npm run test:headed    # Recommended for debugging
npm test              # Headless mode
npm run test:ui       # Interactive Playwright UI
```

## Expected Outcomes
These tests should help identify if the freeze is caused by:
- Stderr blocking when filesystem server outputs messages
- JSON-RPC communication hanging during initialization  
- Process management issues with stdio pipes
- Race conditions between multiple MCP servers

🤖 Generated with [Claude Code](https://claude.ai/code)