### PR TITLE
Add auto-setup functionality to run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -2,6 +2,21 @@
 
 # Tune Chat App Launch Script
 
+# Check if setup has been run (indicated by node_modules directory)
+if [ ! -d "node_modules" ]; then
+    echo "⚠️  Setup hasn't been run yet. Running setup first..."
+    echo ""
+    if [ -f "./setup.sh" ]; then
+        ./setup.sh
+        echo ""
+        echo "✅ Setup completed. Continuing with app launch..."
+        echo ""
+    else
+        echo "❌ setup.sh not found. Please run setup manually with: npm install"
+        exit 1
+    fi
+fi
+
 # Check if .env file exists and source it
 if [ -f ".env" ]; then
     export $(cat .env | grep -v '^#' | xargs)


### PR DESCRIPTION
## Summary
- Modified `run.sh` to automatically check if setup has been run before starting the app
- If `node_modules` directory doesn't exist, automatically runs `./setup.sh` first
- Provides clear user feedback during the auto-setup process
- Includes fallback handling if `setup.sh` is missing

## Test plan
- [x] Verify the script detects missing `node_modules` directory
- [x] Confirm it automatically runs `setup.sh` when needed
- [x] Test that it provides appropriate user feedback
- [x] Ensure it handles missing `setup.sh` gracefully
- [ ] Test the complete flow: remove `node_modules`, run `./run.sh`, verify setup runs automatically

🤖 Generated with [Claude Code](https://claude.ai/code)