### PR TITLE
Remove title bar and add drag functionality

### DIFF
--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -8,6 +8,9 @@
 </head>
 <body>
     <div id="app">
+        <!-- Drag area for window -->
+        <div class="drag-area"></div>
+        
         <!-- Left Sidebar -->
         <aside class="left-sidebar">
             <div class="sidebar-header">

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -15,11 +15,30 @@ body {
     line-height: 1.5;
 }
 
+/* Drag area */
+.drag-area {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 30px;
+    background: transparent;
+    -webkit-app-region: drag;
+    z-index: 1000;
+    pointer-events: auto;
+}
+
+/* Prevent dragging on interactive elements */
+button, input, textarea, select, a, .nav-item, .send-button, .panel-toggle {
+    -webkit-app-region: no-drag;
+}
+
 /* App layout */
 #app {
     height: 100vh;
     display: flex;
     background: #ffffff;
+    padding-top: 30px;
 }
 
 /* Left Sidebar */

--- a/src/main.js
+++ b/src/main.js
@@ -547,7 +547,8 @@ function createWindow() {
             contextIsolation: true,
             preload: path.join(__dirname, 'preload.js')
         },
-        titleBarStyle: 'hiddenInset',
+        titleBarStyle: 'hidden',
+        frame: false,
         vibrancy: 'under-window',
         visualEffectState: 'active'
     });


### PR DESCRIPTION
## Summary
- Removed the Electron window title bar for a cleaner, modern appearance
- Added drag functionality to allow users to easily move the window by clicking and dragging the top area
- Ensured interactive elements (buttons, inputs) remain clickable and non-draggable

## Changes Made
- **Window Configuration**: Set `titleBarStyle: 'hidden'` and `frame: false` in main.js
- **Drag Area**: Added transparent 30px drag area at top of window using `-webkit-app-region: drag`
- **Interactive Elements**: Applied `-webkit-app-region: no-drag` to buttons and inputs to preserve functionality
- **Layout Adjustment**: Added `padding-top: 30px` to main app container to accommodate drag area

## Test Plan
- [x] Verify title bar is completely hidden
- [x] Confirm window can be dragged by clicking and dragging the top area
- [x] Ensure all buttons and interactive elements remain clickable
- [x] Test that the app starts and functions normally
- [x] Verify UI layout is properly adjusted for the drag area

🤖 Generated with [Claude Code](https://claude.ai/code)