### PR TITLE
Add tool call display in chat window

### DIFF
--- a/src/frontend/app.js
+++ b/src/frontend/app.js
@@ -490,20 +490,35 @@ class TuneChatApp {
         }
         
         const toolDiv = document.createElement('div');
-        toolDiv.className = 'tool-call';
+        toolDiv.className = 'tool-call collapsed';
         toolDiv.id = `tool-${toolId}`;
         
         const statusIcon = this.getToolStatusIcon(status);
-        const statusText = this.getToolStatusText(toolName, status);
         
         toolDiv.innerHTML = `
             <div class="tool-call-header">
                 <span class="tool-icon">${statusIcon}</span>
                 <span class="tool-name">${this.escapeHtml(toolName)}</span>
-                <span class="tool-status">${statusText}</span>
             </div>
             <div class="tool-call-details" style="display: none;"></div>
         `;
+        
+        // Add click handler to expand/collapse
+        const header = toolDiv.querySelector('.tool-call-header');
+        header.addEventListener('click', () => {
+            const details = toolDiv.querySelector('.tool-call-details');
+            const isExpanded = toolDiv.classList.contains('expanded');
+            
+            if (isExpanded) {
+                toolDiv.classList.remove('expanded');
+                toolDiv.classList.add('collapsed');
+                details.style.display = 'none';
+            } else {
+                toolDiv.classList.remove('collapsed');
+                toolDiv.classList.add('expanded');
+                details.style.display = 'block';
+            }
+        });
         
         this.chatMessages.appendChild(toolDiv);
         this.scrollToBottom();
@@ -517,21 +532,37 @@ class TuneChatApp {
         const detailsDiv = toolDiv.querySelector('.tool-call-details');
         const toolName = headerDiv.querySelector('.tool-name').textContent;
         
-        // Update status icon and text
+        // Update status icon
         headerDiv.querySelector('.tool-icon').textContent = this.getToolStatusIcon(status);
-        headerDiv.querySelector('.tool-status').textContent = this.getToolStatusText(toolName, status);
+        
+        // Build details content
+        let detailsContent = '';
+        
+        // Add status
+        detailsContent += `<div class="tool-status">${this.getToolStatusText(toolName, status)}</div>`;
         
         // Add execution details if available
-        if (status === 'executing' && input) {
-            detailsDiv.style.display = 'block';
-            detailsDiv.innerHTML = `<pre>${this.escapeHtml(JSON.stringify(input, null, 2))}</pre>`;
+        if (input && Object.keys(input).length > 0) {
+            detailsContent += `
+                <div class="tool-section">
+                    <div class="tool-section-title">Input:</div>
+                    <pre class="tool-input">${this.escapeHtml(JSON.stringify(input, null, 2))}</pre>
+                </div>
+            `;
         }
         
         // Add error details if available
         if (status === 'error' && error) {
-            detailsDiv.style.display = 'block';
-            detailsDiv.innerHTML = `<div class="tool-error">Error: ${this.escapeHtml(error)}</div>`;
+            detailsContent += `
+                <div class="tool-section">
+                    <div class="tool-section-title">Error:</div>
+                    <div class="tool-error">${this.escapeHtml(error)}</div>
+                </div>
+            `;
         }
+        
+        // Update details content
+        detailsDiv.innerHTML = detailsContent;
         
         // Add completion animation
         if (status === 'complete' || status === 'error') {

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -257,6 +257,74 @@ button, input, textarea, select, a, .nav-item, .send-button, .panel-toggle {
     max-width: 60%;
 }
 
+/* Tool call display styles */
+.tool-call {
+    background: #f0f4ff;
+    border: 1px solid #d0e0ff;
+    border-radius: 12px;
+    padding: 10px 14px;
+    margin: 8px 16px;
+    max-width: 80%;
+    align-self: flex-start;
+    font-size: 13px;
+    transition: all 0.2s ease;
+}
+
+.tool-call.tool-finished {
+    background: #f8f9fa;
+    border-color: #e9ecef;
+}
+
+.tool-call-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.tool-icon {
+    font-size: 16px;
+    display: inline-flex;
+}
+
+.tool-name {
+    font-weight: 600;
+    color: #2c3e50;
+    font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+}
+
+.tool-status {
+    color: #6c757d;
+    font-size: 12px;
+    margin-left: auto;
+}
+
+.tool-call-details {
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px solid #e0e0e0;
+}
+
+.tool-call-details pre {
+    font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+    font-size: 11px;
+    background: #f8f9fa;
+    padding: 8px;
+    border-radius: 6px;
+    overflow-x: auto;
+    max-height: 150px;
+    overflow-y: auto;
+    color: #495057;
+}
+
+.tool-error {
+    color: #dc3545;
+    font-size: 12px;
+    padding: 6px 8px;
+    background: #fff5f5;
+    border-radius: 4px;
+    border: 1px solid #ffdddd;
+}
+
 .chat-input-container {
     background: #ffffff;
     border: 1px solid #e9ecef;

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -262,12 +262,19 @@ button, input, textarea, select, a, .nav-item, .send-button, .panel-toggle {
     background: #f0f4ff;
     border: 1px solid #d0e0ff;
     border-radius: 12px;
-    padding: 10px 14px;
     margin: 8px 16px;
     max-width: 80%;
     align-self: flex-start;
     font-size: 13px;
     transition: all 0.2s ease;
+}
+
+.tool-call.collapsed {
+    padding: 8px 12px;
+}
+
+.tool-call.expanded {
+    padding: 10px 14px;
 }
 
 .tool-call.tool-finished {
@@ -279,10 +286,16 @@ button, input, textarea, select, a, .nav-item, .send-button, .panel-toggle {
     display: flex;
     align-items: center;
     gap: 8px;
+    cursor: pointer;
+    user-select: none;
+}
+
+.tool-call-header:hover {
+    opacity: 0.8;
 }
 
 .tool-icon {
-    font-size: 16px;
+    font-size: 14px;
     display: inline-flex;
 }
 
@@ -290,12 +303,14 @@ button, input, textarea, select, a, .nav-item, .send-button, .panel-toggle {
     font-weight: 600;
     color: #2c3e50;
     font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+    font-size: 12px;
 }
 
 .tool-status {
     color: #6c757d;
     font-size: 12px;
-    margin-left: auto;
+    margin-bottom: 8px;
+    padding: 4px 0;
 }
 
 .tool-call-details {
@@ -304,16 +319,31 @@ button, input, textarea, select, a, .nav-item, .send-button, .panel-toggle {
     border-top: 1px solid #e0e0e0;
 }
 
-.tool-call-details pre {
+.tool-section {
+    margin-top: 8px;
+}
+
+.tool-section-title {
+    font-weight: 600;
+    font-size: 11px;
+    color: #6c757d;
+    margin-bottom: 4px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.tool-input {
     font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
     font-size: 11px;
-    background: #f8f9fa;
+    background: #ffffff;
     padding: 8px;
     border-radius: 6px;
     overflow-x: auto;
     max-height: 150px;
     overflow-y: auto;
     color: #495057;
+    border: 1px solid #e9ecef;
+    margin: 0;
 }
 
 .tool-error {

--- a/tests/tool-call-display.spec.js
+++ b/tests/tool-call-display.spec.js
@@ -1,0 +1,89 @@
+const { test, expect } = require('@playwright/test');
+const { spawn } = require('child_process');
+const { join } = require('path');
+
+let electronApp;
+
+test.describe('Tool Call Display', () => {
+    test.beforeAll(async () => {
+        // Start the Electron app
+        electronApp = spawn('npx', ['electron', '.', '--dev'], {
+            cwd: join(__dirname, '..'),
+            env: { ...process.env, NODE_ENV: 'test' }
+        });
+        
+        // Wait for app to start
+        await new Promise(resolve => setTimeout(resolve, 3000));
+    });
+
+    test.afterAll(async () => {
+        if (electronApp) {
+            electronApp.kill();
+        }
+    });
+    
+    test('should display tool calls in chat window', async ({ page }) => {
+        // Load the frontend HTML directly
+        await page.goto('file://' + join(__dirname, '..', 'src', 'frontend', 'index.html'));
+        await page.waitForLoadState('networkidle', { timeout: 1000 });
+        
+        // Type a message that will trigger a tool call
+        const chatInput = await page.locator('#chat-input');
+        await chatInput.fill('check mcp status');
+        
+        // Send the message
+        await page.locator('#send-button').click();
+        
+        // Wait for tool call display to appear
+        const toolCallElement = await page.locator('.tool-call').first();
+        await expect(toolCallElement).toBeVisible({ timeout: 1000 });
+        
+        // Verify tool name is displayed
+        const toolName = await toolCallElement.locator('.tool-name');
+        await expect(toolName).toContainText('check_mcp_status');
+        
+        // Verify initial status
+        const toolStatus = await toolCallElement.locator('.tool-status');
+        await expect(toolStatus).toContainText('Preparing...');
+        
+        // Wait for tool execution
+        await page.waitForTimeout(500);
+        
+        // Verify completion status
+        await expect(toolStatus).toContainText('Completed', { timeout: 1000 });
+        
+        // Verify the tool call has the finished class
+        await expect(toolCallElement).toHaveClass(/tool-finished/);
+    });
+    
+    test('should display tool errors correctly', async ({ page }) => {
+        // Load the frontend HTML directly
+        await page.goto('file://' + join(__dirname, '..', 'src', 'frontend', 'index.html'));
+        await page.waitForLoadState('networkidle', { timeout: 1000 });
+        
+        // Type a message that will trigger a browser tool (which will fail without extension)
+        const chatInput = await page.locator('#chat-input');
+        await chatInput.fill('google artificial intelligence');
+        
+        // Send the message
+        await page.locator('#send-button').click();
+        
+        // Wait for tool call display
+        const toolCallElement = await page.locator('.tool-call').first();
+        await expect(toolCallElement).toBeVisible({ timeout: 1000 });
+        
+        // Verify tool name
+        const toolName = await toolCallElement.locator('.tool-name');
+        await expect(toolName).toContainText('browser_navigate');
+        
+        // Wait for the tool to execute and potentially fail
+        await page.waitForTimeout(1000);
+        
+        // Check if there's an error or success (depending on whether browser extension is connected)
+        const toolStatus = await toolCallElement.locator('.tool-status');
+        const statusText = await toolStatus.textContent();
+        
+        // Tool should either complete or fail
+        expect(['Completed', 'Failed']).toContain(statusText);
+    });
+});

--- a/tests/tool-call-ui-test.spec.js
+++ b/tests/tool-call-ui-test.spec.js
@@ -1,0 +1,113 @@
+const { test, expect } = require('@playwright/test');
+const { join } = require('path');
+
+test.describe('Tool Call UI Components', () => {
+    test('should display tool call UI elements correctly', async ({ page }) => {
+        // Load the frontend HTML with mock electronAPI
+        await page.goto('file://' + join(__dirname, '..', 'src', 'frontend', 'index.html'));
+        
+        // Mock the electronAPI
+        await page.evaluate(() => {
+            window.electronAPI = {
+                sendChatMessage: async () => ({ success: true })
+            };
+        });
+        
+        // Wait for app to be initialized
+        await page.waitForFunction(() => window.chatApp !== undefined, { timeout: 1000 });
+        
+        // Initialize the app
+        await page.evaluate(() => {
+            // Send mock tool call messages
+            window.chatApp.handleBackendMessage({
+                type: 'tool_call_start',
+                toolName: 'read_file',
+                toolId: 'test-tool-1'
+            });
+            
+            setTimeout(() => {
+                window.chatApp.handleBackendMessage({
+                    type: 'tool_call_executing',
+                    toolName: 'read_file',
+                    toolId: 'test-tool-1',
+                    toolInput: { path: '/test/file.txt' }
+                });
+            }, 100);
+            
+            setTimeout(() => {
+                window.chatApp.handleBackendMessage({
+                    type: 'tool_call_complete',
+                    toolName: 'read_file',
+                    toolId: 'test-tool-1',
+                    success: true
+                });
+            }, 200);
+        });
+        
+        // Verify tool call element appears
+        const toolCallElement = await page.locator('.tool-call').first();
+        await expect(toolCallElement).toBeVisible({ timeout: 1000 });
+        
+        // Verify tool name
+        const toolName = await toolCallElement.locator('.tool-name');
+        await expect(toolName).toContainText('read_file');
+        
+        // Wait for status updates
+        await page.waitForTimeout(300);
+        
+        // Verify final status
+        const toolStatus = await toolCallElement.locator('.tool-status');
+        await expect(toolStatus).toContainText('Completed');
+        
+        // Verify finished class is applied
+        await expect(toolCallElement).toHaveClass(/tool-finished/);
+    });
+    
+    test('should display tool error correctly', async ({ page }) => {
+        await page.goto('file://' + join(__dirname, '..', 'src', 'frontend', 'index.html'));
+        
+        // Mock the electronAPI
+        await page.evaluate(() => {
+            window.electronAPI = {
+                sendChatMessage: async () => ({ success: true })
+            };
+        });
+        
+        // Wait for app to be initialized
+        await page.waitForFunction(() => window.chatApp !== undefined, { timeout: 1000 });
+        
+        // Send error tool call messages
+        await page.evaluate(() => {
+            window.chatApp.handleBackendMessage({
+                type: 'tool_call_start',
+                toolName: 'browser_navigate',
+                toolId: 'test-tool-2'
+            });
+            
+            setTimeout(() => {
+                window.chatApp.handleBackendMessage({
+                    type: 'tool_call_complete',
+                    toolName: 'browser_navigate',
+                    toolId: 'test-tool-2',
+                    success: false,
+                    error: 'No connection to browser extension'
+                });
+            }, 100);
+        });
+        
+        // Verify error display
+        const toolCallElement = await page.locator('#tool-test-tool-2');
+        await expect(toolCallElement).toBeVisible({ timeout: 1000 });
+        
+        // Wait for error status
+        await page.waitForTimeout(200);
+        
+        // Verify error status
+        const toolStatus = await toolCallElement.locator('.tool-status');
+        await expect(toolStatus).toContainText('Failed');
+        
+        // Verify error details
+        const errorDetails = await toolCallElement.locator('.tool-error');
+        await expect(errorDetails).toContainText('No connection to browser extension');
+    });
+});

--- a/tests/tool-call-ui-test.spec.js
+++ b/tests/tool-call-ui-test.spec.js
@@ -48,15 +48,27 @@ test.describe('Tool Call UI Components', () => {
         const toolCallElement = await page.locator('.tool-call').first();
         await expect(toolCallElement).toBeVisible({ timeout: 1000 });
         
+        // Verify initial collapsed state
+        await expect(toolCallElement).toHaveClass(/collapsed/);
+        
         // Verify tool name
         const toolName = await toolCallElement.locator('.tool-name');
         await expect(toolName).toContainText('read_file');
         
+        // Click to expand
+        const header = await toolCallElement.locator('.tool-call-header');
+        await header.click();
+        
+        // Verify expanded state
+        await expect(toolCallElement).toHaveClass(/expanded/);
+        const details = await toolCallElement.locator('.tool-call-details');
+        await expect(details).toBeVisible();
+        
         // Wait for status updates
         await page.waitForTimeout(300);
         
-        // Verify final status
-        const toolStatus = await toolCallElement.locator('.tool-status');
+        // Verify status in details
+        const toolStatus = await details.locator('.tool-status');
         await expect(toolStatus).toContainText('Completed');
         
         // Verify finished class is applied
@@ -99,11 +111,19 @@ test.describe('Tool Call UI Components', () => {
         const toolCallElement = await page.locator('#tool-test-tool-2');
         await expect(toolCallElement).toBeVisible({ timeout: 1000 });
         
+        // Verify collapsed state
+        await expect(toolCallElement).toHaveClass(/collapsed/);
+        
+        // Click to expand
+        const header = await toolCallElement.locator('.tool-call-header');
+        await header.click();
+        
         // Wait for error status
         await page.waitForTimeout(200);
         
-        // Verify error status
-        const toolStatus = await toolCallElement.locator('.tool-status');
+        // Verify error status in details
+        const details = await toolCallElement.locator('.tool-call-details');
+        const toolStatus = await details.locator('.tool-status');
         await expect(toolStatus).toContainText('Failed');
         
         // Verify error details


### PR DESCRIPTION
## Summary
- Added visual indicators when AI tools are being called
- Tool calls display compactly by default (just name + status icon)
- Click to expand shows detailed input/output information

## Changes
1. **Backend notifications**: Added IPC messages for tool call lifecycle (start, executing, complete)
2. **Frontend display**: New UI components to show tool calls inline in chat
3. **Collapsible interface**: Click-to-expand functionality for cleaner chat experience
4. **Status indicators**: Visual icons showing tool state (⏳ pending, 🔄 executing, ✅ complete, ❌ error)
5. **OpenAI debugging**: Enhanced logging to diagnose tool call issues with OpenAI provider

## Test plan
- [x] Added comprehensive UI tests for tool call display
- [x] Tested expand/collapse functionality
- [x] Verified error display for failed tool calls
- [ ] Manual testing with real AI conversations
- [ ] Test with all providers (Anthropic, OpenAI, WandB)

🤖 Generated with [Claude Code](https://claude.ai/code)